### PR TITLE
A node with id 0 in neo4j is not properly deduplicated by a Subgraph

### DIFF
--- a/py2neo/data.py
+++ b/py2neo/data.py
@@ -688,7 +688,7 @@ class Node(Entity):
         return not self.__eq__(other)
 
     def __hash__(self):
-        if self.graph and self.identity:
+        if self.graph and self.identity is not None:
             return hash(self.graph.service) ^ hash(self.graph.name) ^ hash(self.identity)
         else:
             return hash(id(self))

--- a/test/integration/test_create.py
+++ b/test/integration/test_create.py
@@ -40,9 +40,9 @@ def test_show_broken_id_0(new_graph):
     counts = {node.identity: ids.count(node.identity) for node in sg.nodes}
 
     # we expect this:
-    #assert set(counts.values()) == set([1])
+    assert set(counts.values()) == set([1])
     # instead we get:
-    assert set(counts.values()) == set([2, 1])
+    # assert set(counts.values()) == set([2, 1])
 
     # doing this again should change nothing, since subgraphs don't keep duplicates
     # *UNLESS* a node's id is 0
@@ -54,9 +54,9 @@ def test_show_broken_id_0(new_graph):
     counts = {node.identity: ids.count(node.identity) for node in sg.nodes}
 
     # we expect this:
-    #assert set(counts.values()) == set([1])
+    assert set(counts.values()) == set([1])
     # instead we get:
-    assert set(counts.values()) == set([4, 1])
+    #assert set(counts.values()) == set([4, 1])
 
 
 def test_can_create_node(graph):


### PR DESCRIPTION
This PR demonstrates the subtle bug where the node with exactly `id = 0`
doesn't behave like any other. When used in Subgraph set operations this
node does not get deduplicated, breaking the expectation that Subgraph
should operate like a set.

I've implemented the fix as well.
